### PR TITLE
Build and push an container image to the repository container registry

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -21,6 +21,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v1
@@ -42,6 +45,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}
           cache-from: type=gha

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,48 @@
+name: Build and push tidybee-frontend image to ghcr.io
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: tiydbee-frontend
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Fetch metadata
+        id: metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: tidybee/tidybee-frontend
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ steps.metadata.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ RUN yarn run build
 
 FROM nginx:1.25.4-alpine3.18@sha256:6a2f8b28e45c4adea04ec207a251fd4a2df03ddc930f782af51e315ebc76e9a9 as production-stage
 WORKDIR /app
+LABEL org.opencontainers.image.source=https://github.com/TidyBee/tidybee-frontend
 COPY --from=build-stage /build/dist /app
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Adds the tidybee-frontend docker image to the repository for a better deployment.
Actions logs example can be found here: https://github.com/TidyBee/tidybee-frontend-deployment/actions/runs/8361092395/job/22888326616

The generated container images can be found [here](https://github.com/orgs/TidyBee/packages?repo_name=tidybee-frontend-deployment) (see screen):
![image](https://github.com/TidyBee/tidybee-frontend/assets/38893947/67492561-d34f-4e13-b483-a475628a3f8c)
